### PR TITLE
Delayed generation of client token.

### DIFF
--- a/ActiveForm.php
+++ b/ActiveForm.php
@@ -15,11 +15,13 @@ class ActiveForm extends \yii\bootstrap\ActiveForm
     public function init()
     {
         parent::init();
-        $id = $this->options['id'];
-        $clientSideKey = Yii::$app->get('braintree')->clientSideKey;
         $view = $this->getView();
         BraintreeAsset::register($view);
-        $view->registerJs("braintree.setup('$clientSideKey', 'custom', {id: '$id'});");
+        $id = $this->options['id'];
+        /** @var Braintree $braintree */
+        $braintree = Yii::$app->get('braintree');
+        $clientToken = $braintree->getClientToken();
+        $view->registerJs("braintree.setup('$clientToken', 'custom', {id: '$id'});");
         $this->fieldClass = ActiveField::className();
     }
 }

--- a/ActiveForm.php
+++ b/ActiveForm.php
@@ -15,13 +15,7 @@ class ActiveForm extends \yii\bootstrap\ActiveForm
     public function init()
     {
         parent::init();
-        $view = $this->getView();
-        BraintreeAsset::register($view);
-        $id = $this->options['id'];
-        /** @var Braintree $braintree */
-        $braintree = Yii::$app->get('braintree');
-        $clientToken = $braintree->getClientToken();
-        $view->registerJs("braintree.setup('$clientToken', 'custom', {id: '$id'});");
+        BraintreeAsset::register($this->getView());
         $this->fieldClass = ActiveField::className();
     }
 }

--- a/Braintree.php
+++ b/Braintree.php
@@ -26,7 +26,7 @@ class Braintree extends Component
     public $merchantId;
     public $publicKey;
     public $privateKey;
-    public $clientSideKey;
+    protected $clientToken;
 
     protected $options;
 
@@ -50,8 +50,15 @@ class Braintree extends Component
             }
             Configuration::$attribute($this->$attribute);
         }
-        $this->clientSideKey = ClientToken::generate();
         parent::init();
+    }
+
+    public function getClientToken($params = [])
+    {
+        if (!isset($this->clientToken)) {
+            $this->clientToken = ClientToken::generate($params);
+        }
+        return $this->clientToken;
     }
 
     /**

--- a/Braintree.php
+++ b/Braintree.php
@@ -26,8 +26,8 @@ class Braintree extends Component
     public $merchantId;
     public $publicKey;
     public $privateKey;
-    protected $clientToken;
 
+    protected $clientToken;
     protected $options;
 
     /**


### PR DESCRIPTION
Generation of client token takes a lot of time, I guess library does request to Braintree server. But client token doesn't required for all operations.
Registration of JS "braintree.setup" removed from ActiveForm, because it is not required in basic case, and when it needed then sometimes other JS should be used, so it is useless in many cases.
