### PR TITLE
Optional caching of data in some methods.

### DIFF
--- a/Braintree.php
+++ b/Braintree.php
@@ -31,6 +31,11 @@ class Braintree extends Component
     protected $options;
 
     /**
+     * @var Plan[] cached plans from Braintree
+     */
+    protected $plans;
+
+    /**
      * Sets up Braintree configuration from config file.
      * @throws \yii\base\InvalidConfigException
      */
@@ -256,19 +261,36 @@ class Braintree extends Component
     }
 
     /**
+     * @param boolean $allowCaching whether to allow caching the result of retrieving of data from Braintree;
+     * when this parameter is true (default), if data was retrieved before,
+     * result will be directly returned when calling this method;
+     * if this parameter is false, this method will always perform request to Braintree to obtain the up-to-date data;
+     * note that this caching is effective only within the same HTTP request
      * @return Plan[]
      */
-    public static function getAllPlans()
+    public function getAllPlans($allowCaching = true)
     {
-        return Plan::all();
+        if (!$allowCaching) {
+            return Plan::all();
+        }
+
+        if (!isset($this->plans)) {
+            $this->plans = Plan::all();
+        }
+        return $this->plans;
     }
 
     /**
+     * @param boolean $allowCaching whether to allow caching the result of retrieving of data from Braintree;
+     * when this parameter is true (default), if data was retrieved before,
+     * result will be directly returned when calling this method;
+     * if this parameter is false, this method will always perform request to Braintree to obtain the up-to-date data;
+     * note that this caching is effective only within the same HTTP request
      * @return array
      */
-    public static function getPlanIds()
+    public function getPlanIds($allowCaching = true)
     {
-        $plans = static::getAllPlans();
+        $plans = $this->getAllPlans($allowCaching);
         $planIds = [];
         foreach ($plans as $plan) {
             $planIds[] = $plan->id;
@@ -278,11 +300,16 @@ class Braintree extends Component
 
     /**
      * @param string $planId
+     * @param boolean $allowCaching whether to allow caching the result of retrieving of data from Braintree;
+     * when this parameter is true (default), if data was retrieved before,
+     * result will be directly returned when calling this method;
+     * if this parameter is false, this method will always perform request to Braintree to obtain the up-to-date data;
+     * note that this caching is effective only within the same HTTP request
      * @return Plan|null
      */
-    public static function getPlanById($planId)
+    public function getPlanById($planId, $allowCaching = true)
     {
-        $plans = static::getAllPlans();
+        $plans = $this->getAllPlans($allowCaching);
         foreach ($plans as $plan) {
             if ($plan->id == $planId) {
                 return $plan;

--- a/BraintreeForm.php
+++ b/BraintreeForm.php
@@ -368,28 +368,43 @@ class BraintreeForm extends Model
     }
 
     /**
+     * @param boolean $allowCaching whether to allow caching the result of retrieving of data from Braintree;
+     * when this parameter is true (default), if data was retrieved before,
+     * result will be directly returned when calling this method;
+     * if this parameter is false, this method will always perform request to Braintree to obtain the up-to-date data;
+     * note that this caching is effective only within the same HTTP request
      * @return \Braintree\Plan[]
      */
-    public static function getAllPlans()
+    public static function getAllPlans($allowCaching = true)
     {
-        return static::getBraintree()->getAllPlans();
+        return static::getBraintree()->getAllPlans($allowCaching);
     }
 
     /**
+     * @param boolean $allowCaching whether to allow caching the result of retrieving of data from Braintree;
+     * when this parameter is true (default), if data was retrieved before,
+     * result will be directly returned when calling this method;
+     * if this parameter is false, this method will always perform request to Braintree to obtain the up-to-date data;
+     * note that this caching is effective only within the same HTTP request
      * @return array
      */
-    public static function getPlanIds()
+    public static function getPlanIds($allowCaching = true)
     {
-        return static::getBraintree()->getPlanIds();
+        return static::getBraintree()->getPlanIds($allowCaching);
     }
 
     /**
      * @param string $planId
+     * @param boolean $allowCaching whether to allow caching the result of retrieving of data from Braintree;
+     * when this parameter is true (default), if data was retrieved before,
+     * result will be directly returned when calling this method;
+     * if this parameter is false, this method will always perform request to Braintree to obtain the up-to-date data;
+     * note that this caching is effective only within the same HTTP request
      * @return \Braintree\Plan|null
      */
-    public static function getPlanById($planId)
+    public static function getPlanById($planId, $allowCaching = true)
     {
-        return static::getBraintree()->getPlanById($planId);
+        return static::getBraintree()->getPlanById($planId, $allowCaching);
     }
 
     /**


### PR DESCRIPTION
Optional caching of data in methods Braintree::getAllPlans, Braintree::getPlanIds, Braintree::getPlanById, BraintreeForm::getAllPlans, BraintreeForm::getPlanIds, BraintreeForm::getPlanById.
